### PR TITLE
Support Commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.16"
 edition = "2021"
 authors = ["Ioannis Nezis <ioannis@nezis.de>"]
 description = "A formatter for SPARQL queries"
-repository = "https://github.com/IoannisNezis/sparql-language-server"
+repository = "https://github.com/IoannisNezis/qlue-ls"
 license = "MIT"
 license-file = "LICENSE"
-keywords = ["SPARQL", "formatter", "lsp", "wasm"]
+keywords = ["SPARQL", "rdf", "lsp", "lsp-server", "wasm"]
 
 [lib]
-name = "sparql_language_server_web"
+name = "qlue_ls"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+use super::lsp::textdocument::DocumentUri;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct PublishDiagnosticsCommandAruments(pub (DocumentUri,));
+
+#[cfg(test)]
+mod test {
+    use super::PublishDiagnosticsCommandAruments;
+
+    #[test]
+    fn serialize() {
+        let arguments = PublishDiagnosticsCommandAruments(("file.rq".to_string(),));
+        let serialized_arguments = serde_json::to_string(&arguments).unwrap();
+        assert_eq!(serialized_arguments, r#"["file.rq"]"#);
+    }
+
+    #[test]
+    fn deserialize() {
+        let serialized_arguments = r#"["file.rq"]"#;
+        let arguments = PublishDiagnosticsCommandAruments(("file.rq".to_string(),));
+        let deserialized_args: PublishDiagnosticsCommandAruments =
+            serde_json::from_str(serialized_arguments).unwrap();
+        assert_eq!(deserialized_args, arguments);
+    }
+}

--- a/src/server/lsp/base_types.rs
+++ b/src/server/lsp/base_types.rs
@@ -1,0 +1,48 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum LSPAny {
+    LSPObject(HashMap<String, LSPAny>),
+    LSPArray(Vec<LSPAny>),
+    String(String),
+    Uinteger(u32),
+    Integer(i32),
+    Decimal(f32),
+    Boolean(bool),
+    Null,
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use super::LSPAny;
+    fn serialize_and_compare(data: LSPAny, expected_result: &str) {
+        let result = serde_json::to_string(&data).unwrap();
+        assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn serialize() {
+        let lsp_object = LSPAny::LSPObject(HashMap::from([("a".to_string(), LSPAny::Integer(42))]));
+        serialize_and_compare(lsp_object, r#"{"a":42}"#);
+        let lsp_array =
+            LSPAny::LSPArray(vec![LSPAny::String("hay".to_string()), LSPAny::Integer(1)]);
+        serialize_and_compare(lsp_array, r#"["hay",1]"#);
+        let string = LSPAny::String("hay".to_string());
+        serialize_and_compare(string, r#""hay""#);
+        let integer = LSPAny::Integer(-42);
+        serialize_and_compare(integer, r#"-42"#);
+        let uinteger = LSPAny::Uinteger(42);
+        serialize_and_compare(uinteger, r#"42"#);
+        let decimal = LSPAny::Decimal(1.1);
+        serialize_and_compare(decimal, r#"1.1"#);
+        let boolean = LSPAny::Boolean(false);
+        serialize_and_compare(boolean, r#"false"#);
+        let null = LSPAny::Null;
+        serialize_and_compare(null, r#"null"#);
+    }
+}

--- a/src/server/lsp/capabilities.rs
+++ b/src/server/lsp/capabilities.rs
@@ -10,9 +10,24 @@ pub struct ServerCapabilities {
     pub document_formatting_provider: DocumentFormattingOptions,
     pub diagnostic_provider: DiagnosticOptions,
     pub code_action_provider: bool,
+    pub execute_command_provider: ExecuteCommandOptions,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ExecuteCommandOptions {
+    #[serde(flatten)]
+    pub work_done_progress_options: WorkDoneProgressOptions,
+    pub commands: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkDoneProgressOptions {
+    pub work_done_progress: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DiagnosticOptions {
     pub identifier: String,
     pub inter_file_dependencies: bool,
@@ -44,7 +59,8 @@ pub struct DocumentFormattingOptions {
 mod tests {
 
     use crate::server::lsp::capabilities::{
-        CompletionOptions, DiagnosticOptions, DocumentFormattingOptions, TextDocumentSyncKind,
+        CompletionOptions, DiagnosticOptions, DocumentFormattingOptions, ExecuteCommandOptions,
+        TextDocumentSyncKind, WorkDoneProgressOptions,
     };
 
     use super::ServerCapabilities;
@@ -64,13 +80,19 @@ mod tests {
                 workspace_diagnostics: false,
             },
             code_action_provider: true,
+            execute_command_provider: ExecuteCommandOptions {
+                work_done_progress_options: WorkDoneProgressOptions {
+                    work_done_progress: true,
+                },
+                commands: vec!["foo".to_string()],
+            },
         };
 
         let serialized = serde_json::to_string(&server_capabilities).unwrap();
 
         assert_eq!(
             serialized,
-            "{\"textDocumentSync\":1,\"hoverProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\"?\"]},\"documentFormattingProvider\":{},\"diagnosticProvider\":{\"identifier\":\"my-ls\",\"inter_file_dependencies\":false,\"workspace_diagnostics\":false},\"codeActionProvider\":true}"
+            r#"{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":["?"]},"documentFormattingProvider":{},"diagnosticProvider":{"identifier":"my-ls","interFileDependencies":false,"workspaceDiagnostics":false},"codeActionProvider":true,"executeCommandProvider":{"workDoneProgress":true,"commands":["foo"]}}"#
         );
     }
 }

--- a/src/server/lsp/messages/mod.rs
+++ b/src/server/lsp/messages/mod.rs
@@ -12,6 +12,7 @@ mod textdocument_publishdiagnostics;
 mod trace;
 mod utils;
 mod window_showmessage;
+mod workspace_exectutecommand;
 
 pub use initialize::*;
 pub use progress::*;
@@ -25,3 +26,4 @@ pub use textdocument_formatting::*;
 pub use textdocument_hover::*;
 pub use textdocument_publishdiagnostics::*;
 pub use trace::*;
+pub use workspace_exectutecommand::*;

--- a/src/server/lsp/messages/workspace_exectutecommand.rs
+++ b/src/server/lsp/messages/workspace_exectutecommand.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+use crate::server::lsp::{
+    base_types::LSPAny,
+    rpc::{RequestMessage, ResponseMessage},
+};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct ExecuteCommandRequest {
+    #[serde(flatten)]
+    pub base: RequestMessage,
+    pub params: ExecuteCommandParams,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct ExecuteCommandParams {
+    pub command: String,
+    pub arguments: Option<Vec<LSPAny>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct ExecuteCommandResponse {
+    #[serde(flatten)]
+    pub base: ResponseMessage,
+    pub result: LSPAny,
+}

--- a/src/server/lsp/mod.rs
+++ b/src/server/lsp/mod.rs
@@ -1,3 +1,4 @@
+pub mod base_types;
 pub mod capabilities;
 mod messages;
 pub mod rpc;

--- a/src/server/message_handler/commands.rs
+++ b/src/server/message_handler/commands.rs
@@ -1,0 +1,63 @@
+use std::any::type_name;
+
+use log::{error, warn};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::server::{
+    commands::PublishDiagnosticsCommandAruments,
+    lsp::{
+        base_types::LSPAny, rpc::BaseMessage, ExecuteCommandParams, PublishDiagnosticsNotification,
+        PublishDiagnosticsPrarams,
+    },
+    message_handler::collect_diagnostics,
+    state::ServerStatus,
+    Server,
+};
+
+pub fn handle_command(server: &Server, params: ExecuteCommandParams) -> Result<LSPAny, String> {
+    match params.command.as_str() {
+        "publishDiagnostics" => {
+            let arguments = parse_command_arguments(&params.arguments)
+                .map_err(to_parse_error::<PublishDiagnosticsCommandAruments>)?;
+            publish_diagnostic(server, &arguments);
+        }
+        unknown_command => {
+            warn!("Received unknown Command: {}", unknown_command);
+        }
+    }
+    // TODO: Return LSP ERROR
+    return Ok(LSPAny::Null);
+}
+
+fn to_parse_error<T>(error: serde_json::Error) -> String {
+    format!(
+        "Could not parse Command arguments \"{}\"\n\n{}",
+        type_name::<T>(),
+        error
+    )
+}
+
+fn parse_command_arguments<T>(arguments: &Option<Vec<LSPAny>>) -> Result<T, serde_json::Error>
+where
+    T: Serialize + DeserializeOwned,
+{
+    let serialized_arguments = serde_json::to_string(&arguments)?;
+    serde_json::from_str(&serialized_arguments)
+}
+
+fn publish_diagnostic(server: &Server, args: &PublishDiagnosticsCommandAruments) {
+    let uri = &args.0 .0;
+    if server.state.status == ServerStatus::Running {
+        if let Some(diagnostics) = collect_diagnostics(server, uri) {
+            let diagnostic_notification = PublishDiagnosticsNotification {
+                base: BaseMessage::new("textDocument/publishDiagnostics"),
+                params: PublishDiagnosticsPrarams {
+                    uri: uri.to_string(),
+                    diagnostics: diagnostics.collect(),
+                },
+            };
+            let message = serde_json::to_string(&diagnostic_notification).unwrap();
+            server.send_message(message);
+        }
+    }
+}

--- a/src/server/message_handler/diagnostic.rs
+++ b/src/server/message_handler/diagnostic.rs
@@ -1,15 +1,35 @@
+use log::error;
+
 use crate::server::{
-    anaysis::{get_undeclared_prefixes, get_unused_prefixes},
-    lsp::{Diagnostic, DiagnosticSeverity},
-    state::ServerState,
+    anaysis::{get_all_uncompressed_uris, get_undeclared_prefixes, get_unused_prefixes},
+    lsp::{textdocument::TextDocumentItem, Diagnostic, DiagnosticSeverity},
+    Server,
 };
 
-pub fn collect_diagnostics(state: &ServerState, uri: &String) -> impl Iterator<Item = Diagnostic> {
-    unused_prefix(state, uri).chain(undeclared_prefix(state, uri))
+pub fn collect_diagnostics<'a>(
+    server: &'a Server,
+    document_uri: &str,
+) -> Option<impl Iterator<Item = Diagnostic> + use<'a>> {
+    if let Some(document) = server.state.get_document(document_uri) {
+        Some(
+            unused_prefix(server, document)
+                .chain(undeclared_prefix(server, document))
+                .chain(uncompressed_uris(server, document)),
+        )
+    } else {
+        error!(
+            "collecting diagnostics for {} failed, document not found!",
+            document_uri
+        );
+        None
+    }
 }
 
-fn unused_prefix(state: &ServerState, uri: &String) -> impl Iterator<Item = Diagnostic> {
-    get_unused_prefixes(state, uri).map(|(prefix, range)| Diagnostic {
+fn unused_prefix<'a>(
+    server: &Server,
+    document: &TextDocumentItem,
+) -> impl Iterator<Item = Diagnostic> + use<'a> {
+    get_unused_prefixes(&server.state, &document.uri).map(|(prefix, range)| Diagnostic {
         range: range.clone(),
         severity: DiagnosticSeverity::Warning,
         source: "qlue-ls (unused_prefix)".to_string(),
@@ -17,11 +37,32 @@ fn unused_prefix(state: &ServerState, uri: &String) -> impl Iterator<Item = Diag
     })
 }
 
-fn undeclared_prefix(state: &ServerState, uri: &String) -> impl Iterator<Item = Diagnostic> {
-    get_undeclared_prefixes(state, uri).map(|(prefix, range)| Diagnostic {
+fn undeclared_prefix(
+    server: &Server,
+    document: &TextDocumentItem,
+) -> impl Iterator<Item = Diagnostic> {
+    get_undeclared_prefixes(&server.state, &document.uri).map(|(prefix, range)| Diagnostic {
         range: range.clone(),
         severity: DiagnosticSeverity::Error,
         source: "qlue-ls (undeclared_prefix)".to_string(),
         message: format!("'{}' is used here, but was never delared\n", prefix),
+    })
+}
+
+fn uncompressed_uris<'a>(
+    server: &'a Server,
+    document: &TextDocumentItem,
+) -> impl Iterator<Item = Diagnostic> + use<'a> {
+    let uncompressed_uris = get_all_uncompressed_uris(server, &document.uri);
+    uncompressed_uris.into_iter().filter_map(|(uri, range)| {
+        match server.compress_uri(&uri[1..uri.len() - 1]) {
+            Some((_prefix, _namespace, curie)) => Some(Diagnostic {
+                source: "dings".to_string(),
+                range,
+                severity: DiagnosticSeverity::Information,
+                message: format!("You might want to compress this Uri\n{} -> {}", uri, curie),
+            }),
+            None => None,
+        }
     })
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 mod anaysis;
+mod commands;
 mod configuration;
 mod lsp;
 mod state;
@@ -7,12 +8,12 @@ mod message_handler;
 
 use configuration::Settings;
 use curies::{Converter, Record};
-use log::{debug, info};
+use log::{debug, error, info};
 use lsp::{
-    capabilities, rpc::BaseMessage, PublishDiagnosticsNotification, PublishDiagnosticsPrarams,
+    capabilities::{self, ExecuteCommandOptions, WorkDoneProgressOptions},
     ServerInfo,
 };
-use message_handler::{collect_diagnostics, dispatch};
+use message_handler::dispatch;
 
 // WARNING: This is a temporary soloution to export the format function directly
 // will remove soon (12.12.24)
@@ -20,7 +21,9 @@ use message_handler::{collect_diagnostics, dispatch};
 pub use message_handler::format_raw;
 
 use state::ServerState;
+use wasm_bindgen::prelude::wasm_bindgen;
 
+#[wasm_bindgen]
 pub struct Server {
     pub(crate) state: ServerState,
     pub(crate) settings: Settings,
@@ -41,6 +44,12 @@ impl Server {
             text_document_sync: capabilities::TextDocumentSyncKind::Incremental,
             hover_provider: true,
             code_action_provider: true,
+            execute_command_provider: ExecuteCommandOptions {
+                work_done_progress_options: WorkDoneProgressOptions {
+                    work_done_progress: true,
+                },
+                commands: vec!["publish diagnostics".to_string()],
+            },
             diagnostic_provider: capabilities::DiagnosticOptions {
                 identifier: "qlue-ls".to_string(),
                 inter_file_dependencies: false,
@@ -70,16 +79,13 @@ impl Server {
         uri_converter.add_record(Record::new("country", "https://ld.admin.ch/country/"));
 
         let version = env!("CARGO_PKG_VERSION");
-        info!("Started Language Server!!1!");
-        info!("version: {}", version);
-        debug!("Capabilities: {:?}", capabilities);
-        debug!("Settings:\n{:?}", settings);
+        info!("Started Language Server: Qlue-ls - version: {}", version);
         Self {
             state: ServerState::new(),
             settings,
             capabilities,
             server_info: ServerInfo {
-                name: "qlue-ls".to_string(),
+                name: "Qlue-ls".to_string(),
                 version: Some(version.to_string()),
             },
             uri_converter,
@@ -105,23 +111,44 @@ impl Server {
         (self.send_message_clusure)(message);
     }
 
+    /// Compresses a raw URI into its CURIE (Compact URI) form and retrieves related metadata.
+    ///
+    /// This method takes a raw URI as input, attempts to find its associated prefix and URI prefix
+    /// from the `uri_converter`, and compresses the URI into its CURIE form. If successful, it
+    /// returns a tuple containing:
+    /// - The prefix associated with the URI.
+    /// - The URI prefix corresponding to the namespace of the URI.
+    /// - The compressed CURIE representation of the URI.
+    ///
+    /// # Parameters
+    /// - `uri`: A string slice representing the raw URI to be compressed.
+    ///
+    /// # Returns
+    /// - `Some((prefix, uri_prefix, curie))` if the URI can be successfully compressed:
+    ///   - `prefix`: A `String` representing the prefix associated with the URI.
+    ///   - `uri_prefix`: A `String` representing the URI namespace prefix.
+    ///   - `curie`: A `String` representing the compressed CURIE form of the URI.
+    /// - `None` if the URI cannot be found or compressed.
+    ///
+    /// # Example
+    /// ```rust
+    /// let uri = "http://example.com/resource";
+    /// if let Some((prefix, uri_prefix, curie)) = instance.compress_uri(uri) {
+    ///     println!("Prefix: {}", prefix);
+    ///     println!("URI Prefix: {}", uri_prefix);
+    ///     println!("CURIE: {}", curie);
+    /// } else {
+    ///     println!("Failed to compress URI.");
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns `None` if:
+    /// - The `uri_converter` fails to find a record associated with the URI.
+    /// - The `uri_converter` fails to compress the URI into a CURIE.
     pub(crate) fn compress_uri(&self, uri: &str) -> Option<(String, String, String)> {
         let record = self.uri_converter.find_by_uri(uri).ok()?;
         let curie = self.uri_converter.compress(uri).ok()?;
         Some((record.prefix.clone(), record.uri_prefix.clone(), curie))
-    }
-
-    // NOTE: i will use this as soon as i master async workers in the web target
-    #[allow(dead_code)]
-    pub fn publish_diagnostic(&self, uri: String) -> String {
-        let notification = PublishDiagnosticsNotification {
-            base: BaseMessage::new("textDocument/publishDiagnostics"),
-            params: PublishDiagnosticsPrarams {
-                uri: uri.clone(),
-                diagnostics: collect_diagnostics(&self.state, &uri).collect(),
-            },
-        };
-        serde_json::to_string(&notification)
-            .expect("Could not parse PublishDiagnosticsNotification")
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -8,7 +8,7 @@ use super::lsp::{
     TextDocumentContentChangeEvent, TraceValue,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ServerStatus {
     Initializing,
     Running,
@@ -74,5 +74,9 @@ impl ServerState {
 
     pub(crate) fn get_tree(&self, uri: &str) -> Option<&Tree> {
         self.documents.get(uri)?.1.as_ref()
+    }
+
+    pub(crate) fn get_document(&self, uri: &str) -> Option<&TextDocumentItem> {
+        Some(&self.documents.get(uri)?.0)
     }
 }


### PR DESCRIPTION
This PR implements LSP commands and implements first command.
The first commands triggers textdocumen/publishDiagnostic.
This is redundant but solves a issue i have with monaco support.