### PR TITLE
Improve the HTTP requests sent to the SPARQL endpoints

### DIFF
--- a/src/server/fetch.rs
+++ b/src/server/fetch.rs
@@ -42,6 +42,8 @@ pub(crate) async fn fetch_sparql_result(
             "Content-Type",
             "application/x-www-form-urlencoded;charset=UTF-8",
         )
+        .header("Accept", "application/sparql-results+json")
+        .header("User-Agent", "qlue-ls/1.0")
         .form(&form_data)
         .send();
 

--- a/src/server/message_handler/completion/start.rs
+++ b/src/server/message_handler/completion/start.rs
@@ -64,6 +64,14 @@ pub(super) async fn completions(
                 CompletionItemKind::Snippet,
                 None,
             ),
+            CompletionItem::new(
+                "Query Metadata",
+                Some("Target endpoint and query description".to_string()),
+                None,
+                "#+ summary: ${1}\n#+ endpoint: ${0}",
+                CompletionItemKind::Snippet,
+                None,
+            ),
         ],
     })
 }


### PR DESCRIPTION
@IoannisNezis 

- [x] Improve the headers of the HTTP requests sent to the SPARQL endpoints when getting completions:
  - added `Accept` header to explicitly request SPARQL results as JSON using the standard mime type: `application/sparql-results+json` (some triplestores will server XML by default if no Accept provided, that was the old school default convention before JSON got crowned Little Prince of the web)
  - added `User-Agent` header, to let the endpoint maintainers  knows who is DDoSing them ;) (it's a good practice and respectful social standard to add a User-Agent to automated systems that are sending HTTP requests, this way it can be better analyzed in the logs, prioritized, blocked, etc)
- [x] added a new start completion to guide user providing basic metadata in their query (summary and target endpoint)

(note that does not fixes this problem: https://github.com/IoannisNezis/Qlue-ls/issues/151)
