### PR TITLE
Conditionalize compilation of WASM logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,21 +8,25 @@ use std::rc::Rc;
 use futures::lock::Mutex;
 use log::error;
 use server::{handle_message, Server};
+
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::JsFuture;
+#[cfg(target_arch = "wasm32")]
 use web_sys::js_sys;
 
 pub use server::format_raw;
 
+#[cfg(target_arch = "wasm32")]
 fn send_message(writer: &web_sys::WritableStreamDefaultWriter, message: String) {
     let _future = JsFuture::from(writer.write_with_chunk(&message.into()));
 }
 
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn init_language_server(writer: web_sys::WritableStreamDefaultWriter) -> Server {
-    #[cfg(target_arch = "wasm32")]
     wasm_logger::init(wasm_logger::Config::default());
-    #[cfg(target_arch = "wasm32")]
     panic::set_hook(Box::new(|info| {
         let msg = info.to_string();
         web_sys::console::error_1(&msg.into());
@@ -35,6 +39,7 @@ pub fn init_language_server(writer: web_sys::WritableStreamDefaultWriter) -> Ser
     Server::new(move |message| send_message(&writer, message))
 }
 
+#[cfg(target_arch = "wasm32")]
 async fn read_message(
     reader: &web_sys::ReadableStreamDefaultReader,
 ) -> Result<(String, bool), String> {
@@ -54,6 +59,7 @@ async fn read_message(
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub async fn listen(server: Server, reader: web_sys::ReadableStreamDefaultReader) {
     let server_rc = Rc::new(Mutex::new(server));

--- a/src/server/message_handler/completion/object.rs
+++ b/src/server/message_handler/completion/object.rs
@@ -11,6 +11,11 @@ use ll_sparql_parser::ast::AstNode;
 use std::rc::Rc;
 use tera::Context;
 
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::task::spawn_local;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local;
+
 pub(super) async fn completions(
     server_rc: Rc<Mutex<Server>>,
     environment: CompletionEnvironment,
@@ -23,7 +28,7 @@ pub(super) async fn completions(
     let server_rc_1 = server_rc.clone();
     let template_context_1 = template_context.clone();
     let environment_1 = environment.clone();
-    wasm_bindgen_futures::spawn_local(async move {
+    spawn_local(async move {
         match dispatch_completion_query(
             server_rc_1,
             &environment_1,

--- a/src/server/message_handler/completion/predicate.rs
+++ b/src/server/message_handler/completion/predicate.rs
@@ -12,6 +12,11 @@ use ll_sparql_parser::{ast::AstNode, syntax_kind::SyntaxKind};
 use std::rc::Rc;
 use tera::Context;
 
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::task::spawn_local;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local;
+
 pub(super) async fn completions(
     server_rc: Rc<Mutex<Server>>,
     environment: CompletionEnvironment,
@@ -25,7 +30,7 @@ pub(super) async fn completions(
     let server_rc_1 = server_rc.clone();
     let template_context_1 = template_context.clone();
     let environment_1 = environment.clone();
-    wasm_bindgen_futures::spawn_local(async move {
+    spawn_local(async move {
         match dispatch_completion_query(
             server_rc_1,
             &environment_1,


### PR DESCRIPTION
Adds conditional compilation guards to the `wasm` specific variants of async calls.

Fixes panics on non wasm architectures identified in #241 .