### PR TITLE
Support non-global linking in development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 log/
+pkg/

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ init_dev:
 	wasm-pack build --release --target web
 	echo "building ll-sparql-parser wasm binary"
 	cd ./crates/parser/ && wasm-pack build --release --target web
-	echo "linking against local packages"
-	cd ./pkg/ && npm link
-	cd ./crates/parser/pkg/ && npm link
-	cd editor && npm link ll-sparql-parser qlue-ls
 	echo "starting dev server"
 	cd editor && npm run dev
 

--- a/docs/docs/07_development.md
+++ b/docs/docs/07_development.md
@@ -12,8 +12,6 @@ Here is a quick guide to set this project up for development.
 
 ## Initial Setup
 
-You will only have to do this once.
-
 In the `justfile` and `Makefile` you will find the target `init_dev`, run it:
 
 ```bash
@@ -29,13 +27,10 @@ make init_dev
 It will:
 
 - install node dependencies
-- build wasm binaries
-- link against local packages
+- build wasm binaries (qlue-ls and ll-sparql-parser)
 - run the vite dev server
 
-If you don't have [just](https://github.com/casey/just) or [make](https://wiki.ubuntuusers.de/Makefile/) installed:
-
-**Install [just](https://github.com/casey/just)**
+The development setup uses Vite path aliases to automatically resolve local WASM packages from the `pkg/` directories during development, while production builds use the npm package versions specified in `package.json`. 
 
 
 ## Automatically rebuild on change

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -2498,7 +2498,6 @@
             "integrity": "sha512-2MvEpSYabUrsJAoq5qCOBGAlkICjfjunrnLcx3YAk2XV7TvAIhomlKsAgR4H/4uns5rAfYmj7Wet5KRtc8dPIg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sveltejs/acorn-typescript": "^1.0.5",
                 "@types/cookie": "^0.6.0",
@@ -2532,7 +2531,6 @@
             "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
                 "debug": "^4.4.1",
@@ -3155,7 +3153,6 @@
             "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3256,7 +3253,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001716",
                 "electron-to-chromium": "^1.5.149",
@@ -3965,7 +3961,6 @@
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-17.2.1.tgz",
             "integrity": "sha512-GGTO5isYIBUlFgkG5yt9OSewi1ZqjbGmwdHJdAR9KqSkDPerS3u24yZfSVLxmjVCoLO+Av1+6yy+mC8bzHpsQg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": "17.2.1",
                 "@codingame/monaco-vscode-api": "17.2.1"
@@ -4158,7 +4153,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -4181,7 +4175,6 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -4198,7 +4191,6 @@
             "integrity": "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "prettier": "^3.0.0",
                 "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -4329,7 +4321,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.2.tgz",
             "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.7"
             },
@@ -4439,7 +4430,6 @@
             "integrity": "sha512-3kNMwstMB2VUBod63H6BQPzBr7NiPRR9qFVzrWqW/nU4ulqqAYZsJ6E7m8LYFoRzuW6yylx+uzdgKVhFKZVf4Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.3.0",
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -4558,7 +4548,6 @@
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4617,7 +4606,6 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
             "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -4860,7 +4848,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
             "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },

--- a/editor/vite.config.ts
+++ b/editor/vite.config.ts
@@ -2,6 +2,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import wasm from 'vite-plugin-wasm';
+import path from 'path';
 
 export default defineConfig(({ mode }) => ({
     optimizeDeps: {
@@ -11,6 +12,12 @@ export default defineConfig(({ mode }) => ({
             'vscode-textmate',
             'vscode-oniguruma'
         ]
+    },
+    resolve: {
+      alias: mode === 'development' ? [
+        { find: /^qlue-ls(\?.*)?$/, replacement: path.resolve(__dirname, '../pkg') + '$1' },
+        { find: /^ll-sparql-parser(\?.*)?$/, replacement: path.resolve(__dirname, '../crates/parser/pkg') + '$1' }
+      ] : [] 
     },
     server: {
         allowedHosts: true,

--- a/justfile
+++ b/justfile
@@ -8,10 +8,6 @@ init_dev:
 	wasm-pack build --release --target web
 	echo "building ll-sparql-parser wasm binary"
 	cd ./crates/parser/ && wasm-pack build --release --target web
-	echo "linking against local packages"
-	cd ./pkg/ && npm link
-	cd ./crates/parser/pkg/ && npm link
-	cd editor && npm link ll-sparql-parser qlue-ls
 	echo "starting dev server"
 	cd editor && npm run dev
 


### PR DESCRIPTION
> [!NOTE]  
 _This was useful for my development purposes, feel free to reject if not useful in the general sense_

This removes the need for linking the system binary for `qlue-ls` in order to make new changes available to development mode runs of the web editor.  For developers who manage system binaries declaratively (eg nix) it's not always feasible to link / unlink a system package dynamically.

Instead, in this diff we leverage [vite modes](https://vite.dev/guide/env-and-mode#modes) to dynamically configure the the include path.