### PR TITLE
Correct offsets for completion replacement on enter

### DIFF
--- a/src/server/message_handler/completion/utils.rs
+++ b/src/server/message_handler/completion/utils.rs
@@ -213,8 +213,7 @@ fn render_rdf_term(
 /// The context.search_term MUST be not None!
 pub(super) fn get_replace_range(context: &CompletionEnvironment) -> Range {
     Range {
-        start: context.trigger_textdocument_position,
-        end: Position::new(
+        start: Position::new(
             context.trigger_textdocument_position.line,
             context.trigger_textdocument_position.character
                 - context
@@ -228,6 +227,7 @@ pub(super) fn get_replace_range(context: &CompletionEnvironment) -> Range {
                     })
                     .unwrap_or(0),
         ),
+        end: context.trigger_textdocument_position,
     }
 }
 


### PR DESCRIPTION
This PR corrects some of the offset logic that would cause a selected completion to be directly interspersed into the typed text, rather than replacing it outright.

I encountered this when I enabled completion queries for qlue-ls in neovim, where partially typed text can trigger a completion.  In the monaco based web editor, at least in the present version, it seems completions are only triggered positionally (eg when the cursor is in the object position of a triple, run the object completion queries).  Please do correct me however if I missed this.

When typing:
<img width="540" height="128" alt="image" src="https://github.com/user-attachments/assets/f0bec6aa-e9f1-4578-899f-f7f0d0c94209" />

On enter:
<img width="365" height="115" alt="image" src="https://github.com/user-attachments/assets/6eb4cc12-e44b-479b-a4ef-95c634760af9" />

Prior to this fix, the inserted text would be: `Expsp:ExperimentSpecification `, with the partially entered term left intact at the start of the completion.