### PR TITLE
Add folding range for every block with curly brackets

### DIFF
--- a/src/server/message_handler/folding_range/mod.rs
+++ b/src/server/message_handler/folding_range/mod.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use futures::lock::Mutex;
 use ll_sparql_parser::{
+    SyntaxNode,
     ast::{AstNode, Prologue},
     syntax_kind::SyntaxKind,
 };
@@ -10,7 +11,8 @@ use crate::server::{
     Server,
     lsp::{
         FoldingRange, FoldingRangeKind, FoldingRangeRequest, FoldingRangeResponse,
-        errors::LSPError, textdocument::Range,
+        errors::LSPError,
+        textdocument::{Position, Range},
     },
 };
 
@@ -20,18 +22,26 @@ pub(super) async fn handle_folding_range_request(
     request: FoldingRangeRequest,
 ) -> Result<(), LSPError> {
     let server = server_rc.lock().await;
-    let mut result = vec![];
     let document = server.state.get_document(request.get_document_uri())?;
     let tree = server
         .state
         .get_cached_parse_tree(request.get_document_uri())?
         .tree;
+    let result = compute_folding_ranges(&tree, &document.text);
+    let mut response = FoldingRangeResponse::new(request.get_id());
+    response.set_result(result);
+    server.send_message(response)
+}
+
+/// Compute all folding ranges for a parsed document:
+/// the prologue (as an imports region) and every curly-brace delimited group graph pattern.
+fn compute_folding_ranges(tree: &SyntaxNode, text: &str) -> Vec<FoldingRange> {
+    let mut result = vec![];
     if let Some(prologue) = tree
         .first_child()
         .and_then(|child| child.first_child().and_then(Prologue::cast))
     {
-        let range =
-            Range::from_byte_offset_range(prologue.syntax().text_range(), &document.text).unwrap();
+        let range = Range::from_byte_offset_range(prologue.syntax().text_range(), text).unwrap();
         result.push(FoldingRange {
             start_line: range.start.line,
             end_line: range.end.line,
@@ -42,31 +52,129 @@ pub(super) async fn handle_folding_range_request(
         });
     }
     // Fold any block delimited by curly braces
-    for node in tree.descendants() {
-        if node.kind() != SyntaxKind::GroupGraphPattern {
-            continue;
-        }
-        let Some(content) = node.first_child() else {
-            continue;
-        };
-        let Some(open) = Range::from_byte_offset_range(node.text_range(), &document.text) else {
-            continue;
-        };
-        let Some(inner) = Range::from_byte_offset_range(content.text_range(), &document.text) else {
-            continue;
-        };
-        if inner.end.line > open.start.line {
-            result.push(FoldingRange {
-                start_line: open.start.line,
-                end_line: inner.end.line,
-                start_character: None,
-                end_character: None,
-                kind: None,
-                collapsed_text: None,
-            });
-        }
+    result.extend(
+        tree.descendants()
+            .filter(|node| node.kind() == SyntaxKind::GroupGraphPattern)
+            .filter_map(|node| {
+                let open_brace = node
+                    .first_child_or_token()
+                    .filter(|token| token.kind() == SyntaxKind::LCurly)?
+                    .into_token()?;
+                let close_brace = node
+                    .last_child_or_token()
+                    .filter(|token| token.kind() == SyntaxKind::RCurly)?
+                    .into_token()?;
+                let open_position =
+                    Position::from_byte_index(open_brace.text_range().start(), text)?;
+                let close_position =
+                    Position::from_byte_index(close_brace.text_range().start(), text)?;
+                // NOTE: A folding range collapses `start_line..=end_line`, so end the fold on
+                // the line before the closing brace to keep the `}` visible. `checked_sub`
+                // also drops single-line blocks, which have nothing to fold.
+                let end_line = close_position.line.checked_sub(1)?;
+                // INFO: Skip degenerate ranges (e.g. empty two-line blocks) that would fold nothing.
+                if end_line <= open_position.line {
+                    return None;
+                }
+                Some(FoldingRange {
+                    start_line: open_position.line,
+                    end_line,
+                    start_character: None,
+                    end_character: None,
+                    kind: None,
+                    collapsed_text: None,
+                })
+            }),
+    );
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use ll_sparql_parser::parse;
+
+    use super::compute_folding_ranges;
+    use crate::server::lsp::FoldingRangeKind;
+
+    /// Returns only the brace-delimited (GGP) folding ranges as `(start_line, end_line)` tuples.
+    fn ggp_folds(text: &str) -> Vec<(u32, u32)> {
+        let (tree, _) = parse(text);
+        compute_folding_ranges(&tree, text)
+            .into_iter()
+            .filter(|range| range.kind.is_none())
+            .map(|range| (range.start_line, range.end_line))
+            .collect()
     }
-    let mut response = FoldingRangeResponse::new(request.get_id());
-    response.set_result(result);
-    server.send_message(response)
+
+    #[test]
+    fn single_group_graph_pattern() {
+        let text = "SELECT * {\n  ?s ?p ?o .\n}";
+        // Fold ends on the line before the closing brace so the `}` stays visible.
+        assert_eq!(ggp_folds(text), vec![(0, 1)]);
+    }
+
+    #[test]
+    fn nested_group_graph_patterns() {
+        let text = "SELECT * {\n  ?s ?p ?o .\n  {\n    ?a ?b ?c .\n  }\n}";
+        let mut folds = ggp_folds(text);
+        folds.sort();
+        assert_eq!(folds, vec![(0, 4), (2, 3)]);
+    }
+
+    #[test]
+    fn optional_group_graph_pattern() {
+        let text = "SELECT * {\n  ?s ?p ?o .\n  OPTIONAL {\n    ?a ?b ?c .\n  }\n}";
+        let mut folds = ggp_folds(text);
+        folds.sort();
+        assert_eq!(folds, vec![(0, 4), (2, 3)]);
+    }
+
+    #[test]
+    fn union_group_graph_patterns() {
+        let text = "SELECT * {\n  {\n    ?s ?p ?o .\n  }\n  UNION\n  {\n    ?a ?b ?c .\n  }\n}";
+        let mut folds = ggp_folds(text);
+        folds.sort();
+        assert_eq!(folds, vec![(0, 7), (1, 2), (5, 6)]);
+    }
+
+    #[test]
+    fn single_line_group_graph_pattern_is_not_folded() {
+        // Opening and closing brace share a line, so there is nothing to fold.
+        let text = "SELECT * { ?s ?p ?o . }";
+        assert!(ggp_folds(text).is_empty());
+    }
+
+    #[test]
+    fn empty_group_graph_pattern_does_not_fold_closing_brace() {
+        // Regression: an empty block spanning two lines must not fold the `}` away.
+        let text = "SELECT * WHERE {\n}";
+        assert!(ggp_folds(text).is_empty());
+    }
+
+    #[test]
+    fn subselect_group_graph_pattern() {
+        let text = "SELECT * {\n  {\n    SELECT * {\n      ?s ?p ?o .\n    }\n  }\n}";
+        let mut folds = ggp_folds(text);
+        folds.sort();
+        assert_eq!(folds, vec![(0, 5), (1, 4), (2, 3)]);
+    }
+
+    #[test]
+    fn prologue_produces_imports_range() {
+        let text = "PREFIX ex: <http://example.org/>\nSELECT * {\n  ?s ?p ?o .\n}";
+        let (tree, _) = parse(text);
+        let ranges = compute_folding_ranges(&tree, text);
+        let imports: Vec<_> = ranges
+            .iter()
+            .filter(|range| range.kind == Some(FoldingRangeKind::Imports))
+            .collect();
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].start_line, 0);
+    }
+
+    #[test]
+    fn query_without_group_graph_pattern_has_no_ggp_folds() {
+        let text = "PREFIX ex: <http://example.org/>";
+        assert!(ggp_folds(text).is_empty());
+    }
 }

--- a/src/server/message_handler/folding_range/mod.rs
+++ b/src/server/message_handler/folding_range/mod.rs
@@ -1,7 +1,10 @@
 use std::rc::Rc;
 
 use futures::lock::Mutex;
-use ll_sparql_parser::ast::{AstNode, Prologue};
+use ll_sparql_parser::{
+    ast::{AstNode, Prologue},
+    syntax_kind::SyntaxKind,
+};
 
 use crate::server::{
     Server,
@@ -37,6 +40,31 @@ pub(super) async fn handle_folding_range_request(
             kind: Some(FoldingRangeKind::Imports),
             collapsed_text: Some(prologue.text()),
         });
+    }
+    // Fold any block delimited by curly braces
+    for node in tree.descendants() {
+        if node.kind() != SyntaxKind::GroupGraphPattern {
+            continue;
+        }
+        let Some(content) = node.first_child() else {
+            continue;
+        };
+        let Some(open) = Range::from_byte_offset_range(node.text_range(), &document.text) else {
+            continue;
+        };
+        let Some(inner) = Range::from_byte_offset_range(content.text_range(), &document.text) else {
+            continue;
+        };
+        if inner.end.line > open.start.line {
+            result.push(FoldingRange {
+                start_line: open.start.line,
+                end_line: inner.end.line,
+                start_character: None,
+                end_character: None,
+                kind: None,
+                collapsed_text: None,
+            });
+        }
     }
     let mut response = FoldingRangeResponse::new(request.get_id());
     response.set_result(result);


### PR DESCRIPTION
# Pull Request

**What this PR does**

Add folding range for every block with curly brackets

**Why this is needed**

For now Qlue-ls only provide a folding range for the prefixes declaration. By convention most LS provide folding ranges for content of open/closed brackets. In the case of SPARQL that's relevant for curly brackets (sub-query, service block...)

**Checklist**

- [x] Code builds and compiles (`cargo build`)
- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Lints pass (`cargo clippy`)
- [x] Changes are limited to a single concern
- [x] Documentation updated (if applicable)

**Additional context**


I could not find an easy way to visually test the changes, the web editor in `editor` is gone (but it is still mentioned in the docs)

<details><summary>So I used this index.html</summary>

I put it in `playground/index.html` and ran `npx http-server`

```html
<!doctype html>
<meta charset="utf-8" />
<title>qlue-ls playground</title>
<style>
  html, body { margin: 0; height: 100%; }
  #editor { width: 100%; height: calc(100% - 34px); }
</style>
<div id="editor"></div>

<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js"></script>
<script>
  const MONACO = "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min";
  require.config({ paths: { vs: MONACO + "/vs" } });
  self.MonacoEnvironment = {
    getWorkerUrl: () =>
      `data:text/javascript;charset=utf-8,` +
      encodeURIComponent(
        `self.MonacoEnvironment={baseUrl:'${MONACO}/'};importScripts('${MONACO}/vs/base/worker/workerMain.js');`
      ),
  };

  const SAMPLE = `PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>

SELECT ?person ?name WHERE {
  ?person a foaf:Person .
  OPTIONAL {
    ?person foaf:name ?name .
  }
  {
    SELECT ?person WHERE {
      ?person foaf:knows ?other .
    }
  }
  {
    ?person foaf:mbox ?mbox .
  } UNION {
    ?person foaf:homepage ?hp .
  }
  SERVICE <https://example.org/sparql> {
    ?person foaf:depiction ?img .
  }
}`;

  require(["vs/editor/editor.main"], async () => {
    const wasm = await import("../pkg/qlue_ls.js");
    await wasm.default();

    // minimal JSON-RPC client over the wasm Web Streams interface
    let nextId = 1;
    const pending = new Map();
    let reqController;
    const requestStream = new ReadableStream({ start: (c) => (reqController = c) });
    const responseStream = new WritableStream({
      write(chunk) {
        let msg;
        try { msg = JSON.parse(chunk); } catch { return; }
        if (msg.id !== undefined && pending.has(msg.id)) {
          pending.get(msg.id)(msg);
          pending.delete(msg.id);
        }
      },
    });
    const server = wasm.init_language_server(responseStream.getWriter());
    wasm.listen(server, requestStream.getReader()); // runs forever, do not await
    const send = (m) => reqController.enqueue(JSON.stringify({ jsonrpc: "2.0", ...m }));
    const request = (method, params) => new Promise((res) => { const id = nextId++; pending.set(id, res); send({ id, method, params }); });
    const notify = (method, params) => send({ method, params });
    const uri = "file:///query.rq";
    await request("initialize", { processId: null, rootUri: null, capabilities: {} });
    notify("initialized", {});
    notify("textDocument/didOpen", {
      textDocument: { uri, languageId: "sparql", version: 1, text: SAMPLE },
    });

    // Monaco editor + folding provider backed by qlue-ls
    monaco.languages.register({ id: "sparql" });
    let version = 1;
    const editor = monaco.editor.create(document.getElementById("editor"), {
      value: SAMPLE,
      language: "sparql",
      theme: "vs-dark",
      automaticLayout: true,
      folding: true,
      showFoldingControls: "always",
    });
    editor.getModel().onDidChangeContent(() => {
      version += 1;
      notify("textDocument/didChange", {
        textDocument: { uri, version },
        contentChanges: [{ text: editor.getValue() }],
      });
    });
    monaco.languages.registerFoldingRangeProvider("sparql", {
      async provideFoldingRanges() {
        const resp = await request("textDocument/foldingRange", { textDocument: { uri } });
        const ranges = resp.result || [];
        return ranges.map((r) => ({
          start: r.startLine + 1, // LSP 0-based -> Monaco 1-based
          end: r.endLine + 1,
          kind: r.kind === "imports" ? monaco.languages.FoldingRangeKind.Imports : undefined,
        }));
      },
    });
  });
</script>
```
</details>