### PR TITLE
Add packaging using `cargo-deb`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,16 @@ version = "3.3.1"
 edition = "2024"
 authors = ["Ioannis Nezis <ioannis@nezis.de>"]
 description = "A language server for SPARQL"
+documentation = "https://docs.qlue-ls.com"
 repository = "https://github.com/IoannisNezis/qlue-ls"
 license-file = "LICENSE"
 keywords = ["SPARQL", "rdf", "lsp", "lsp-server", "wasm"]
+
+[package.metadata.deb]
+maintainer = "Julian Mundhahs <mundhahj@tf.uni-freiburg.de>"
+extended-description = "TODO; the default (README) is not well suited for this"
+section = "devel"
+priority = "optional"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
# Pull Request

**What this PR does**

Add some basic (not yet finished) configuration to `Cargo.toml` so that this project can be packaged using `cargo-deb`. `cargo-deb` is a simplified build process (comparable to what we do with `cpack` for `qlever`) that only generates a `.deb`. 

**Why this is needed**

As a user I want to be able to install `qlue-ls` easily. Compiling might be a hurdle for some. The package can be added to the qlever apt repository so that users (who already have that set up) can simply do `apt install qlue-ls`. The apt repository is a good addition to the (currently only other) binary distribution via pypi.

**Checklist**

Not applicable

**Additional context**

- A first build is already available in the qlever repo - just [set it up](https://docs.qlever.dev/quickstart/#debian-and-ubuntu) and `apt install qlue-ls` to try it out.
- Adding a new version to the repository is currently done by me. When we switch to another repository management tool it should be possible that you can add new versions on your own.